### PR TITLE
Setting reaper timeout to 2 hours for inrix sized data

### DIFF
--- a/lib/reaper/data_slurper/http.ex
+++ b/lib/reaper/data_slurper/http.ex
@@ -37,6 +37,6 @@ defmodule Reaper.DataSlurper.Http do
   end
 
   defp download_timeout do
-    Application.get_env(:reaper, :http_download_timeout, 60_000)
+    Application.get_env(:reaper, :http_download_timeout, 7_200_000)
   end
 end


### PR DESCRIPTION
/voltron#56

co-authored-by: Jessie Morris <jmorris2@pillartechnology.com>